### PR TITLE
Change Bg Color for Spans in Dark Mode and Light Mode & Free WhitePaper Section

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -314,3 +314,12 @@
     transform: rotate(360deg);
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .from-white {
+    --tw-gradient-from: var(--tw-gradient-stops);
+  }
+  .bg-white {
+    background-color: var(--tw-gradient-stops);
+  }
+}

--- a/frontend/src/components/ui/resource-card.tsx
+++ b/frontend/src/components/ui/resource-card.tsx
@@ -212,37 +212,37 @@ export function ResourceCard({ resource, className }: ResourceCardProps) {
           {resource.type === 'github' && (
             <>
               {resource.stars !== undefined && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#3D4D40] text-[#B4D5A7] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <Star className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{resource.stars.toLocaleString()}</span>
                 </span>
               )}
               {resource.author && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#3D4D40] text-[#B4D5A7] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <User className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{resource.author}</span>
                 </span>
               )}
               {resource.language && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#3D4D40] text-[#B4D5A7] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <span className="h-2 w-2 rounded-full bg-[#83C167]" />
                   <span className="truncate">{resource.language}</span>
                 </span>
               )}
               {resource.forks_count !== undefined && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#3D4D40] text-[#B4D5A7] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <GitFork className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{resource.forks_count.toLocaleString()}</span>
                 </span>
               )}
               {resource.open_issues_count !== undefined && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#3D4D40] text-[#B4D5A7] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{resource.open_issues_count.toLocaleString()}</span>
                 </span>
               )}
               {resource.updated_at && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#3D4D40] text-[#B4D5A7] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <Calendar className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">Updated {formatDate(resource.updated_at)}</span>
                 </span>
@@ -253,13 +253,13 @@ export function ResourceCard({ resource, className }: ResourceCardProps) {
           {resource.type === 'blog_post' && (
             <>
               {resource.source && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#EDF3EB] text-[#568C3F] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <Tag className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{resource.source}</span>
                 </span>
               )}
               {(resource.date || resource.published_date) && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#EDF3EB] text-[#568C3F] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <Calendar className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{formatDate(resource.date || resource.published_date)}</span>
                 </span>
@@ -270,7 +270,7 @@ export function ResourceCard({ resource, className }: ResourceCardProps) {
           {(resource.type === 'job' || resource.type === 'job_listing') && (
             <>
               {resource.company && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#EDF3EB] text-[#568C3F] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <Building className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{resource.company}</span>
                 </span>
@@ -278,7 +278,7 @@ export function ResourceCard({ resource, className }: ResourceCardProps) {
               
               {/* Show country extracted from location */}
               {resource.location && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#EDF3EB] text-[#568C3F] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <Globe className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{extractCountry(resource.location)}</span>
                 </span>
@@ -286,7 +286,7 @@ export function ResourceCard({ resource, className }: ResourceCardProps) {
               
               {/* Show remote status */}
               {isRemote(resource) && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#EDF3EB] text-[#568C3F] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <LaptopIcon className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">Remote</span>
                 </span>
@@ -294,7 +294,7 @@ export function ResourceCard({ resource, className }: ResourceCardProps) {
               
               {/* Show month posted */}
               {(resource.date || resource.published_date || resource.added_at) && (
-                <span className="flex items-center gap-1 min-w-0 bg-[#EDF3EB] text-[#568C3F] px-2 py-0.5 rounded-full">
+                <span className="flex items-center gap-1 min-w-0 bg-[#6E2FD5] text-white px-2 py-0.5 rounded-full">
                   <Clock className="h-3.5 w-3.5 flex-shrink-0" />
                   <span className="truncate">{getMonthPosted(resource.date || resource.published_date || resource.added_at)}</span>
                 </span>
@@ -354,7 +354,7 @@ export function ResourceCard({ resource, className }: ResourceCardProps) {
                 ).map((skill, index) => (
                   <span
                     key={index}
-                    className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-[#EDF3EB] text-[#568C3F]"
+                    className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-[#6E2FD5] text-white"
                   >
                     <CheckCircle2 className="h-3 w-3 flex-shrink-0" />
                     {skill.charAt(0).toUpperCase() + skill.slice(1)}

--- a/frontend/src/components/ui/whitepaper-section.tsx
+++ b/frontend/src/components/ui/whitepaper-section.tsx
@@ -95,7 +95,7 @@ export function WhitepaperSection() {
               </motion.h2>
               
               <motion.p 
-                className="text-xl text-gray-600"
+                className="text-xl text-gray-600 dark:text-gray-300"
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
@@ -116,7 +116,7 @@ export function WhitepaperSection() {
                   <div key={highlight.title} className="flex flex-col items-center text-center p-4">
                     <highlight.icon className="w-8 h-8 text-primary mb-3" />
                     <h3 className="font-semibold mb-2">{highlight.title}</h3>
-                    <p className="text-sm text-gray-600">{highlight.description}</p>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">{highlight.description}</p>
                   </div>
                 ))}
               </motion.div>
@@ -134,7 +134,7 @@ export function WhitepaperSection() {
                   {keyBenefits.map((benefit) => (
                     <div key={benefit} className="flex items-start gap-2">
                       <CheckCircle2 className="w-5 h-5 text-green-500 flex-shrink-0 mt-1" />
-                      <span className="text-gray-700">{benefit}</span>
+                      <span className="text-gray-700 dark:text-gray-300">{benefit}</span>
                     </div>
                   ))}
                 </div>
@@ -149,7 +149,7 @@ export function WhitepaperSection() {
               viewport={{ once: true }}
             >
               <h3 className="text-2xl font-semibold mb-4">Download Free Whitepaper</h3>
-              <p className="text-gray-600 mb-6">
+              <p className="text-gray-600 dark:text-gray-300 mb-6">
                 Get practical insights and strategies to build better developer programs and measure their impact.
               </p>
               


### PR DESCRIPTION
### AIM of PR: 
The Text inside the span is not clearly visible in `Dark Mode`

### Provided Solution: 
- Changing the Background Color of the Spans from `#3D4D40` to `#6E2FD5` (Primary Color) in both the Light and Dark Mode of the screen.
- The changes are made for the Tabs `Blog Posts`, `GitHub Programs`, and `Job Listings`
- The Free Whitepaper Section's UI improved in the Dark Mode.
---
### Reference Screenshot

#### 1. Job Listings Tab
![Screenshot from 2025-03-19 12-21-40](https://github.com/user-attachments/assets/ed895993-bdc3-4658-b301-f7cddfdd439c)
![Screenshot from 2025-03-19 12-25-44](https://github.com/user-attachments/assets/0d21a46a-a83c-4554-82f7-426ceb16693b)
---
#### 2. GitHub Programs Tab
![Screenshot from 2025-03-19 12-21-30](https://github.com/user-attachments/assets/3260265e-41a8-4ac7-9334-08a5933377f1)
![Screenshot from 2025-03-19 12-25-32](https://github.com/user-attachments/assets/ed2db86c-8b4b-4202-b307-b3aab5cdc6e4)
---
#### 3. Blog Posts Tab

![Screenshot from 2025-03-19 12-21-20](https://github.com/user-attachments/assets/d8b5aaf3-5b92-40e2-80ff-41874a97e0c4)
![Screenshot from 2025-03-19 12-25-23](https://github.com/user-attachments/assets/ff6648ff-0f18-4a3a-9660-6c61cfa6f705)

---
#### 4. Free WhitePaper Section
![Screenshot from 2025-03-19 14-33-32](https://github.com/user-attachments/assets/84824838-2db7-453c-a570-11265f46fa04)
![Screenshot from 2025-03-19 14-33-22](https://github.com/user-attachments/assets/5ac61f7f-c7bf-45e3-9d93-75d58cbfdb64)