### PR TITLE
Configure Vercel deployment for guide.devrelasservice.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.vercel

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,15 +7,6 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'http',
-        hostname: 'localhost',
-      },
-    ],
-  },
-  output: 'standalone',
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Remove `output: 'standalone'` from next.config.ts (Vercel uses its own build, standalone is for Docker)
- Remove `localhost` remote image pattern (not applicable in production)
- Add `.vercel` to .gitignore

## Deployment
- Vercel project: `devrelguide` linked to this repo with `frontend/` as root directory
- Custom domain `guide.devrelasservice.com` added to the project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and deployment settings.
  * Refined version control ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->