### PR TITLE
Fix social preview images, OG/Twitter meta tags, and favicon

### DIFF
--- a/frontend/src/app/blog/ai-coding-agents-compared-2026/layout.tsx
+++ b/frontend/src/app/blog/ai-coding-agents-compared-2026/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
     title: 'AI Coding Agents Compared: 2026 Guide',
     description: 'A practical comparison of every major AI coding agent — model access, ecosystem depth, privacy, and which workflow fits your team.',
     type: 'article',
-    url: 'https://learn.devrelasservice.com/blog/ai-coding-agents-compared-2026',
+    url: 'https://learndevrel.com/blog/ai-coding-agents-compared-2026',
     siteName: 'DevRel Guide',
   },
   twitter: {

--- a/frontend/src/app/blog/ai-coding-agents-compared-2026/opengraph-image.tsx
+++ b/frontend/src/app/blog/ai-coding-agents-compared-2026/opengraph-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 15 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/ai-coding-agents-compared-2026/twitter-image.tsx
+++ b/frontend/src/app/blog/ai-coding-agents-compared-2026/twitter-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 15 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/claude-code-developer-workflow/layout.tsx
+++ b/frontend/src/app/blog/claude-code-developer-workflow/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
     title: 'Claude Code: Hooks, Skills, and MCP Workflow',
     description: 'How Claude Code\'s ecosystem of hooks, skills, MCP servers, and persistent memory turns a terminal agent into a complete development workflow.',
     type: 'article',
-    url: 'https://learn.devrelasservice.com/blog/claude-code-developer-workflow',
+    url: 'https://learndevrel.com/blog/claude-code-developer-workflow',
     siteName: 'DevRel Guide',
   },
   twitter: {

--- a/frontend/src/app/blog/claude-code-developer-workflow/opengraph-image.tsx
+++ b/frontend/src/app/blog/claude-code-developer-workflow/opengraph-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 12 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/claude-code-developer-workflow/twitter-image.tsx
+++ b/frontend/src/app/blog/claude-code-developer-workflow/twitter-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 12 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/mcp-vs-a2a/layout.tsx
+++ b/frontend/src/app/blog/mcp-vs-a2a/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'MCP vs A2A: The Complete Guide to AI Agent Protocols in 2026',
+  description: 'The definitive comparison of MCP and A2A — covering MCP Apps, Streamable HTTP, Google ADK integration, and how these protocols work together.',
+  openGraph: {
+    title: 'MCP vs A2A: The Complete Guide to AI Agent Protocols in 2026',
+    description: 'The definitive comparison of MCP and A2A — covering MCP Apps, Streamable HTTP, Google ADK integration, and how these protocols work together.',
+    type: 'article',
+    url: 'https://learndevrel.com/blog/mcp-vs-a2a',
+    siteName: 'DevRel Guide',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'MCP vs A2A: Complete Guide to AI Agent Protocols',
+    description: 'The definitive comparison of MCP and A2A — covering MCP Apps, Streamable HTTP, Google ADK integration, and how these protocols work together.',
+  },
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/frontend/src/app/blog/mcp-vs-a2a/opengraph-image.tsx
+++ b/frontend/src/app/blog/mcp-vs-a2a/opengraph-image.tsx
@@ -1,0 +1,51 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'MCP vs A2A: The Complete Guide to AI Agent Protocols in 2026'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(56,189,248,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(56,189,248,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(56,189,248,0.15)', border: '1px solid rgba(56,189,248,0.3)' }}>
+            <span style={{ color: '#7dd3fc', fontSize: '16px', fontWeight: 600 }}>MCP</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(56,189,248,0.1)', border: '1px solid rgba(56,189,248,0.2)' }}>
+            <span style={{ color: '#7dd3fc', fontSize: '16px', fontWeight: 600 }}>A2A</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(56,189,248,0.1)', border: '1px solid rgba(56,189,248,0.2)' }}>
+            <span style={{ color: '#7dd3fc', fontSize: '16px', fontWeight: 600 }}>Protocols</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '48px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>MCP vs A2A</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>The Complete Guide to AI Agent Protocols in 2026</p>
+        </div>
+        <div style={{ display: 'flex', gap: '24px', alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>MCP Apps</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(56,189,248,0.6)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Streamable HTTP</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(56,189,248,0.4)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Google ADK</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(56,189,248,0.3)', marginTop: '6px' }} />
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>Updated February 2026 · 20 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/blog/mcp-vs-a2a/twitter-image.tsx
+++ b/frontend/src/app/blog/mcp-vs-a2a/twitter-image.tsx
@@ -1,0 +1,51 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'MCP vs A2A: The Complete Guide to AI Agent Protocols in 2026'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(56,189,248,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(56,189,248,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(56,189,248,0.15)', border: '1px solid rgba(56,189,248,0.3)' }}>
+            <span style={{ color: '#7dd3fc', fontSize: '16px', fontWeight: 600 }}>MCP</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(56,189,248,0.1)', border: '1px solid rgba(56,189,248,0.2)' }}>
+            <span style={{ color: '#7dd3fc', fontSize: '16px', fontWeight: 600 }}>A2A</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(56,189,248,0.1)', border: '1px solid rgba(56,189,248,0.2)' }}>
+            <span style={{ color: '#7dd3fc', fontSize: '16px', fontWeight: 600 }}>Protocols</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '48px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>MCP vs A2A</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>The Complete Guide to AI Agent Protocols in 2026</p>
+        </div>
+        <div style={{ display: 'flex', gap: '24px', alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>MCP Apps</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(56,189,248,0.6)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Streamable HTTP</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(56,189,248,0.4)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Google ADK</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(56,189,248,0.3)', marginTop: '6px' }} />
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>Updated February 2026 · 20 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/blog/moltbook-ai-social-network/layout.tsx
+++ b/frontend/src/app/blog/moltbook-ai-social-network/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
     title: 'Moltbook: Inside the AI-Only Social Network',
     description: 'A Reddit-style platform exclusively for AI bots raised questions about agent autonomy, prompt injection at scale, and what happens when machines form communities.',
     type: 'article',
-    url: 'https://learn.devrelasservice.com/blog/moltbook-ai-social-network',
+    url: 'https://learndevrel.com/blog/moltbook-ai-social-network',
     siteName: 'DevRel Guide',
   },
   twitter: {

--- a/frontend/src/app/blog/moltbook-ai-social-network/opengraph-image.tsx
+++ b/frontend/src/app/blog/moltbook-ai-social-network/opengraph-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 14 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/moltbook-ai-social-network/twitter-image.tsx
+++ b/frontend/src/app/blog/moltbook-ai-social-network/twitter-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 14 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/opencode-terminal-coding-agent/layout.tsx
+++ b/frontend/src/app/blog/opencode-terminal-coding-agent/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
     title: 'OpenCode: 95K Stars, 2.5M Monthly Developers',
     description: 'With 2.5M monthly developers, 75+ model providers, and zero hype, OpenCode became the quiet workhorse of terminal-based AI-assisted development.',
     type: 'article',
-    url: 'https://learn.devrelasservice.com/blog/opencode-terminal-coding-agent',
+    url: 'https://learndevrel.com/blog/opencode-terminal-coding-agent',
     siteName: 'DevRel Guide',
   },
   twitter: {

--- a/frontend/src/app/blog/opencode-terminal-coding-agent/opengraph-image.tsx
+++ b/frontend/src/app/blog/opencode-terminal-coding-agent/opengraph-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 10 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/opencode-terminal-coding-agent/twitter-image.tsx
+++ b/frontend/src/app/blog/opencode-terminal-coding-agent/twitter-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 10 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/ralph-loop-ai-coding/layout.tsx
+++ b/frontend/src/app/blog/ralph-loop-ai-coding/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
     title: 'The Ralph Loop: AI Coding\'s Most Important Technique',
     description: 'Named after Ralph Wiggum, this deliberately simple technique of running coding agents in a loop against specs is reshaping how software gets built.',
     type: 'article',
-    url: 'https://learn.devrelasservice.com/blog/ralph-loop-ai-coding',
+    url: 'https://learndevrel.com/blog/ralph-loop-ai-coding',
     siteName: 'DevRel Guide',
   },
   twitter: {

--- a/frontend/src/app/blog/ralph-loop-ai-coding/opengraph-image.tsx
+++ b/frontend/src/app/blog/ralph-loop-ai-coding/opengraph-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 10 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/ralph-loop-ai-coding/twitter-image.tsx
+++ b/frontend/src/app/blog/ralph-loop-ai-coding/twitter-image.tsx
@@ -41,7 +41,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 · 10 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/webmcp-chrome-ai-agents/layout.tsx
+++ b/frontend/src/app/blog/webmcp-chrome-ai-agents/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
     title: 'WebMCP: Chrome Just Turned Every Website Into an API for AI Agents',
     description: 'Google and Microsoft shipped WebMCP in Chrome 146. Websites expose structured tools to AI agents via navigator.modelContext. 89% fewer tokens, 98% accuracy, and the web becomes agent-native.',
     type: 'article',
-    url: 'https://learn.devrelasservice.com/blog/webmcp-chrome-ai-agents',
+    url: 'https://learndevrel.com/blog/webmcp-chrome-ai-agents',
     siteName: 'DevRel Guide',
   },
   twitter: {

--- a/frontend/src/app/blog/webmcp-chrome-ai-agents/opengraph-image.tsx
+++ b/frontend/src/app/blog/webmcp-chrome-ai-agents/opengraph-image.tsx
@@ -42,7 +42,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 &middot; 18 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/webmcp-chrome-ai-agents/twitter-image.tsx
+++ b/frontend/src/app/blog/webmcp-chrome-ai-agents/twitter-image.tsx
@@ -42,7 +42,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
-          <span style={{ color: '#475569', fontSize: '16px' }}>learn.devrelasservice.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
           <span style={{ color: '#475569', fontSize: '16px' }}>February 2026 &middot; 18 min read</span>
         </div>
       </div>

--- a/frontend/src/app/blog/why-devrel-is-needed/layout.tsx
+++ b/frontend/src/app/blog/why-devrel-is-needed/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Why DevRel is Needed for Your Company: Building Bridges to Developer Communities',
+  description: 'DevRel professionals connect companies and developers by giving technical guidance, support, and resources. Learn why DevRel has become essential.',
+  openGraph: {
+    title: 'Why DevRel is Needed for Your Company',
+    description: 'DevRel professionals connect companies and developers by giving technical guidance, support, and resources. Learn why DevRel has become essential.',
+    type: 'article',
+    url: 'https://learndevrel.com/blog/why-devrel-is-needed',
+    siteName: 'DevRel Guide',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Why DevRel is Needed for Your Company',
+    description: 'DevRel professionals connect companies and developers by giving technical guidance, support, and resources. Learn why DevRel has become essential.',
+  },
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/frontend/src/app/blog/why-devrel-is-needed/opengraph-image.tsx
+++ b/frontend/src/app/blog/why-devrel-is-needed/opengraph-image.tsx
@@ -1,0 +1,52 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Why DevRel is Needed for Your Company'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(52,211,153,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(52,211,153,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(52,211,153,0.15)', border: '1px solid rgba(52,211,153,0.3)' }}>
+            <span style={{ color: '#6ee7b7', fontSize: '16px', fontWeight: 600 }}>DevRel</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(52,211,153,0.1)', border: '1px solid rgba(52,211,153,0.2)' }}>
+            <span style={{ color: '#6ee7b7', fontSize: '16px', fontWeight: 600 }}>Strategy</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(52,211,153,0.1)', border: '1px solid rgba(52,211,153,0.2)' }}>
+            <span style={{ color: '#6ee7b7', fontSize: '16px', fontWeight: 600 }}>Community</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '44px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Why DevRel is Needed</h1>
+          <h1 style={{ color: '#f1f5f9', fontSize: '44px', fontWeight: 700, lineHeight: 1.15, margin: '8px 0 0 0', letterSpacing: '-0.02em' }}>for Your Company</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Building Bridges to Developer Communities</p>
+        </div>
+        <div style={{ display: 'flex', gap: '24px', alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Advocacy</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(52,211,153,0.6)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Community</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(52,211,153,0.4)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Growth</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(52,211,153,0.3)', marginTop: '6px' }} />
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>March 2025 · 10 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/blog/why-devrel-is-needed/twitter-image.tsx
+++ b/frontend/src/app/blog/why-devrel-is-needed/twitter-image.tsx
@@ -1,0 +1,52 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Why DevRel is Needed for Your Company'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(52,211,153,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(52,211,153,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(52,211,153,0.15)', border: '1px solid rgba(52,211,153,0.3)' }}>
+            <span style={{ color: '#6ee7b7', fontSize: '16px', fontWeight: 600 }}>DevRel</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(52,211,153,0.1)', border: '1px solid rgba(52,211,153,0.2)' }}>
+            <span style={{ color: '#6ee7b7', fontSize: '16px', fontWeight: 600 }}>Strategy</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(52,211,153,0.1)', border: '1px solid rgba(52,211,153,0.2)' }}>
+            <span style={{ color: '#6ee7b7', fontSize: '16px', fontWeight: 600 }}>Community</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '44px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Why DevRel is Needed</h1>
+          <h1 style={{ color: '#f1f5f9', fontSize: '44px', fontWeight: 700, lineHeight: 1.15, margin: '8px 0 0 0', letterSpacing: '-0.02em' }}>for Your Company</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Building Bridges to Developer Communities</p>
+        </div>
+        <div style={{ display: 'flex', gap: '24px', alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Advocacy</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(52,211,153,0.6)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Community</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(52,211,153,0.4)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Growth</span>
+            <div style={{ display: 'flex', width: '260px', height: '4px', borderRadius: '2px', background: 'rgba(52,211,153,0.3)', marginTop: '6px' }} />
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>March 2025 · 10 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -20,7 +20,11 @@ const architectsDaughter = Architects_Daughter({
 });
 
 export const metadata: Metadata = {
-  title: "DevRel Guide",
+  metadataBase: new URL('https://learndevrel.com'),
+  title: {
+    default: 'DevRel Guide',
+    template: '%s | DevRel Guide',
+  },
   description: "A comprehensive collection of Developer Relations resources, tools, and job opportunities.",
   icons: {
     icon: [
@@ -28,6 +32,20 @@ export const metadata: Metadata = {
       { url: "/Icon.svg", type: "image/svg+xml" },
     ],
     apple: "/Icon.svg",
+  },
+  openGraph: {
+    title: 'DevRel Guide',
+    description: 'A comprehensive collection of Developer Relations resources, tools, and job opportunities.',
+    url: 'https://learndevrel.com',
+    siteName: 'DevRel Guide',
+    type: 'website',
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'DevRel Guide',
+    description: 'A comprehensive collection of Developer Relations resources, tools, and job opportunities.',
+    creator: '@anthropicdevrel',
   },
 };
 

--- a/frontend/src/app/opengraph-image.tsx
+++ b/frontend/src/app/opengraph-image.tsx
@@ -1,0 +1,51 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'DevRel Guide — Developer Relations Resources, Tools & Community'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(0,51,102,0.3) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(0,51,102,0.2) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(0,51,102,0.25)', border: '1px solid rgba(0,51,102,0.4)' }}>
+            <span style={{ color: '#93c5fd', fontSize: '16px', fontWeight: 600 }}>DevRel</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(0,51,102,0.15)', border: '1px solid rgba(0,51,102,0.3)' }}>
+            <span style={{ color: '#93c5fd', fontSize: '16px', fontWeight: 600 }}>Resources</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(0,51,102,0.15)', border: '1px solid rgba(0,51,102,0.3)' }}>
+            <span style={{ color: '#93c5fd', fontSize: '16px', fontWeight: 600 }}>Community</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '56px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>DevRel Guide</h1>
+          <p style={{ color: '#94a3b8', fontSize: '26px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Developer Relations resources, tools, and job opportunities</p>
+        </div>
+        <div style={{ display: 'flex', gap: '24px', alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Blog</span>
+            <div style={{ display: 'flex', width: '200px', height: '4px', borderRadius: '2px', background: 'rgba(0,51,102,0.6)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Tools</span>
+            <div style={{ display: 'flex', width: '200px', height: '4px', borderRadius: '2px', background: 'rgba(0,51,102,0.4)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Jobs</span>
+            <div style={{ display: 'flex', width: '200px', height: '4px', borderRadius: '2px', background: 'rgba(0,51,102,0.3)', marginTop: '6px' }} />
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>February 2026</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/twitter-image.tsx
+++ b/frontend/src/app/twitter-image.tsx
@@ -1,0 +1,51 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'DevRel Guide — Developer Relations Resources, Tools & Community'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(0,51,102,0.3) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(0,51,102,0.2) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(0,51,102,0.25)', border: '1px solid rgba(0,51,102,0.4)' }}>
+            <span style={{ color: '#93c5fd', fontSize: '16px', fontWeight: 600 }}>DevRel</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(0,51,102,0.15)', border: '1px solid rgba(0,51,102,0.3)' }}>
+            <span style={{ color: '#93c5fd', fontSize: '16px', fontWeight: 600 }}>Resources</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(0,51,102,0.15)', border: '1px solid rgba(0,51,102,0.3)' }}>
+            <span style={{ color: '#93c5fd', fontSize: '16px', fontWeight: 600 }}>Community</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '56px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>DevRel Guide</h1>
+          <p style={{ color: '#94a3b8', fontSize: '26px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Developer Relations resources, tools, and job opportunities</p>
+        </div>
+        <div style={{ display: 'flex', gap: '24px', alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Blog</span>
+            <div style={{ display: 'flex', width: '200px', height: '4px', borderRadius: '2px', background: 'rgba(0,51,102,0.6)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Tools</span>
+            <div style={{ display: 'flex', width: '200px', height: '4px', borderRadius: '2px', background: 'rgba(0,51,102,0.4)', marginTop: '6px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ color: '#64748b', fontSize: '14px' }}>Jobs</span>
+            <div style={{ display: 'flex', width: '200px', height: '4px', borderRadius: '2px', background: 'rgba(0,51,102,0.3)', marginTop: '6px' }} />
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>February 2026</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}


### PR DESCRIPTION
## Summary

- **Root layout**: Added `metadataBase: new URL('https://learndevrel.com')` for proper absolute URL generation across all pages — this was the root cause of social preview images not resolving on Twitter, LinkedIn, Discord, Slack, etc.
- **Homepage OG/Twitter images**: Created `opengraph-image.tsx` and `twitter-image.tsx` at the root app level — homepage previously had zero social preview tags
- **Added OpenGraph + Twitter metadata** to root `layout.tsx` with proper `og:title`, `og:description`, `og:url`, `og:site_name`, `twitter:card`, `twitter:creator`
- **Fixed wrong domain** in 18 files across 6 blog posts: `learn.devrelasservice.com` → `learndevrel.com`
- **Added missing metadata** for 2 blog posts (`mcp-vs-a2a`, `why-devrel-is-needed`): `layout.tsx` with SEO metadata, `opengraph-image.tsx`, and `twitter-image.tsx`
- **Removed empty** `kubectl-mcp-server-kubernetes-ai` directory

## Test plan

- [ ] Verify homepage meta tags via view-source
- [ ] Test Twitter Card preview via Twitter Card Validator
- [ ] Test LinkedIn preview via LinkedIn Post Inspector
- [ ] Verify favicon shows DevRelGuide mascot (not Vercel logo) in browser tab
- [ ] Check blog post previews for mcp-vs-a2a and why-devrel-is-needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Open Graph and Twitter image generators for blog posts and homepage, enabling enhanced social media previews.
  * Added layout metadata and social image support for new blog articles.

* **Chores**
  * Updated domain URLs across blog posts and social image generators from previous domain to new domain.
  * Enhanced root app metadata with Open Graph and Twitter card configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->