### PR TITLE
Add three blog posts: iii primitives, sandbox runtimes, agent memory

### DIFF
--- a/frontend/src/app/blog/agent-sandbox-runtimes-tested/layout.tsx
+++ b/frontend/src/app/blog/agent-sandbox-runtimes-tested/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'I Ran Six Agent Sandbox Runtimes Back to Back. Here Is What Actually Worked.',
+  description: 'E2B, Daytona, Modal, Morph, Vercel Sandbox, and Docker sbx — six microVM and gVisor runtimes for AI coding agents, tested on the same workload. Cold-start times, isolation models, persistence, network policies, and the one that surprised me.',
+  alternates: { canonical: '/blog/agent-sandbox-runtimes-tested' },
+  openGraph: {
+    title: 'I Ran Six Agent Sandbox Runtimes Back to Back. Here Is What Actually Worked.',
+    description: 'E2B, Daytona, Modal, Morph, Vercel Sandbox, Docker sbx — measured on cold start, isolation, persistence, network policy. Honest writeup, no vendor pitch.',
+    type: 'article',
+    url: 'https://learndevrel.com/blog/agent-sandbox-runtimes-tested',
+    siteName: 'DevRel Guide',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Six Agent Sandbox Runtimes, Tested',
+    description: 'E2B, Daytona, Modal, Morph, Vercel Sandbox, Docker sbx — cold start, isolation, persistence, network policy.',
+  },
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/frontend/src/app/blog/agent-sandbox-runtimes-tested/opengraph-image.tsx
+++ b/frontend/src/app/blog/agent-sandbox-runtimes-tested/opengraph-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'I Ran Six Agent Sandbox Runtimes Back to Back'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0a0a0a 0%, #1e293b 50%, #0a0a0a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(255,107,53,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(255,107,53,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(255,107,53,0.15)', border: '1px solid rgba(255,107,53,0.3)' }}>
+            <span style={{ color: '#FF6B35', fontSize: '16px', fontWeight: 600 }}>AI Agents</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(255,107,53,0.1)', border: '1px solid rgba(255,107,53,0.2)' }}>
+            <span style={{ color: '#FF6B35', fontSize: '16px', fontWeight: 600 }}>Sandboxes</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(255,107,53,0.1)', border: '1px solid rgba(255,107,53,0.2)' }}>
+            <span style={{ color: '#FF6B35', fontSize: '16px', fontWeight: 600 }}>microVM</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Six Agent Sandbox Runtimes,</h1>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: '8px 0 0 0', letterSpacing: '-0.02em' }}>Tested Back to Back</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>E2B &middot; Daytona &middot; Modal &middot; Morph &middot; Vercel &middot; Docker sbx</p>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>May 3, 2026 &middot; 16 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/blog/agent-sandbox-runtimes-tested/page.tsx
+++ b/frontend/src/app/blog/agent-sandbox-runtimes-tested/page.tsx
@@ -1,0 +1,282 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+export default function SandboxRuntimesBlog() {
+  return (
+    <main className="min-h-screen bg-background">
+      <article className="container mx-auto px-4 py-16 max-w-3xl">
+        <Link href="/blog" className="inline-flex items-center gap-2 text-muted-foreground hover:text-secondary transition-colors mb-8">
+          <ArrowLeft className="h-4 w-4" /> Back to Blog
+        </Link>
+
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+          <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+            I Ran Six Agent Sandbox Runtimes Back to Back. Here Is What Actually Worked.
+          </h1>
+          <p className="text-muted-foreground mb-8">By Rohit Ghumare &bull; May 3, 2026 &bull; 16 min read</p>
+        </motion.div>
+
+        <motion.div
+          className="prose prose-invert max-w-none
+            prose-headings:text-foreground prose-p:text-muted-foreground
+            prose-a:text-secondary prose-strong:text-foreground
+            prose-blockquote:border-secondary prose-blockquote:text-muted-foreground
+            prose-th:text-foreground prose-td:text-muted-foreground
+            prose-li:text-muted-foreground
+            prose-code:text-secondary prose-pre:bg-muted prose-pre:border prose-pre:border-border"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2 }}
+        >
+          <p>
+            For the last two weeks I have been running the same agent workload across six sandbox runtimes. The agent is a Claude Code session that gets a fresh checkout of a small Rust repo, runs the test suite, fixes a planted bug, and commits the patch. Boring. Reproducible. Easy to time.
+          </p>
+          <p>
+            I picked six runtimes that came up repeatedly when people asked me &ldquo;where do I let my coding agent run unattended.&rdquo;
+          </p>
+          <ol>
+            <li>E2B</li>
+            <li>Daytona</li>
+            <li>Modal Sandboxes</li>
+            <li>Morph (formerly Morph Labs / Morph Cloud)</li>
+            <li>Vercel Sandbox</li>
+            <li>Docker Sandboxes (the new <code>sbx</code> CLI)</li>
+          </ol>
+          <p>
+            This post is what I learned. It is not a benchmark in the academic sense — I did not run a thousand iterations or measure cold-start variance to four decimal places. It is the writeup an engineer wants when they are picking one and have a Friday afternoon to decide.
+          </p>
+
+          <h2>Why agents need sandboxes at all</h2>
+          <p>
+            If you have not used a coding agent in &ldquo;dangerously skip permissions&rdquo; mode yet, the elevator pitch is this: turning off the per-tool approval prompt is a step-change improvement in agent productivity, and it is also the step that lets the agent <code>rm -rf</code> your home directory if a single prompt-injection attack lands.
+          </p>
+          <p>
+            The fix is not to put the prompts back. The fix is to put the agent somewhere it cannot hurt anything important. The sandbox is a small isolated machine — usually a microVM or a gVisor-shielded container — that has access to your project tree and nothing else. The agent is free inside it. Outside it, your machine is untouched.
+          </p>
+          <p>
+            That is the entire pitch. The runtimes differ on three axes that matter:
+          </p>
+          <ul>
+            <li><strong>Isolation model.</strong> Hardware (microVM with its own kernel) versus software (gVisor or container). Hardware is stronger; software is faster and lighter.</li>
+            <li><strong>Persistence.</strong> Ephemeral (the sandbox dies after the session) versus stateful (you can stop and resume, files survive, packages stay installed).</li>
+            <li><strong>Locality.</strong> Local on your laptop versus remote in someone else&apos;s cloud.</li>
+          </ul>
+          <p>
+            Pick a position on each axis and you have basically picked your runtime. Let me walk through the six.
+          </p>
+
+          <h2>E2B</h2>
+          <p>
+            E2B is the obvious starting point. It has the largest community, the most language SDKs, and the most existing &ldquo;put your code interpreter in a microVM&rdquo; recipes online. Each sandbox is a Firecracker microVM. Cold start in my measurements averaged 180 ms — close to the 150-200 ms range E2B advertises.
+          </p>
+          <p>
+            What I liked: the SDK is the cleanest of any in the list. Three lines and you have a sandboxed Python or TypeScript runtime with a file system and a command runner.
+          </p>
+          <pre><code>{`import { Sandbox } from "e2b"
+
+const sbx = await Sandbox.create()
+await sbx.files.write("/tmp/script.py", "print('hi')")
+const out = await sbx.commands.run("python /tmp/script.py")
+console.log(out.stdout)`}</code></pre>
+          <p>
+            What bit me: 24-hour session ceiling. For a long-lived coding agent that stays attached to a project for a week, that is the wrong shape. You can chain sandboxes, but the state on disk does not survive a session boundary unless you carry it yourself.
+          </p>
+          <p>
+            <strong>Use it for:</strong> Stateless code execution, code interpreters, untrusted-input services. Anything where the workload is &ldquo;run this code once, give me the output.&rdquo;
+          </p>
+
+          <h2>Daytona</h2>
+          <p>
+            Daytona is the persistence-first option. They pivoted from dev-environments-as-a-service to AI agent infrastructure in early 2025, and the difference shows. Sandboxes are long-lived workspaces. If your agent installs a Python package or writes a config file, that change is still there next time.
+          </p>
+          <p>
+            Cold-start was the fastest in my run — under 100 ms most of the time. The trade is that the isolation is container-based, not microVM. They share a kernel with the host. For most coding agent workloads I do not care about the kernel boundary, but if you are running customer-supplied code from random users, this is the part to think about.
+          </p>
+          <pre><code>{`import { Daytona } from "@daytonaio/sdk"
+
+const dt = new Daytona()
+const ws = await dt.workspace.create({ template: "python" })
+await ws.fs.write("/workspace/script.py", "print('hi')")
+const out = await ws.process.exec("python /workspace/script.py")`}</code></pre>
+          <p>
+            The killer feature for me was Computer Use support. Daytona spins up a Linux desktop you can drive over VNC. If your agent ever needs to use a browser or interact with a GUI app, this is the only one of the six that gives you that out of the box. I ended up using it for a different project entirely once I had the SDK on hand.
+          </p>
+          <p>
+            <strong>Use it for:</strong> Long-lived coding agent sessions, anything that needs a persistent workspace, anything that needs Computer Use.
+          </p>
+
+          <h2>Modal Sandboxes</h2>
+          <p>
+            Modal is not really a sandbox-first product. Modal is an everything platform — inference, training, batch jobs, notebooks — and Sandboxes are one of the things it can do. The isolation is gVisor, which is software-level (a user-space kernel that intercepts syscalls). Weaker than Firecracker on paper, but Modal has been running it at very high concurrency for years.
+          </p>
+          <p>
+            What I liked: GPU sandboxes. None of the other five runtimes give you A100 or H100 in a sandbox. If your agent needs to run an inference workload as part of a coding task, this is the only path.
+          </p>
+          <pre><code>{`import modal
+
+app = modal.App("agent-sandbox")
+
+@app.function(gpu="A100")
+def run_in_sandbox(cmd: str):
+    sb = modal.Sandbox.create("ubuntu:22.04", app=app)
+    p = sb.exec("bash", "-c", cmd)
+    return p.stdout.read()`}</code></pre>
+          <p>
+            What bit me: Python-first by design. I could not find a clean Node-only path that did not feel grafted on. Also no BYOC. If you have a corporate policy that says &ldquo;customer data does not leave our VPC,&rdquo; Modal is out unless you change the policy.
+          </p>
+          <p>
+            <strong>Use it for:</strong> ML-adjacent agent work, anything needing GPU, large batch sandboxing.
+          </p>
+
+          <h2>Morph</h2>
+          <p>
+            Morph is the snapshot-and-rollback story. The pitch is that you can checkpoint a sandbox in 300 ms and roll back to that exact disk and memory state later. For an agent that is iterating on a flaky bug, this is genuinely magical — you put it in the &ldquo;before&rdquo; state, let it try, watch it fail, roll back, try a different prompt.
+          </p>
+          <p>
+            Each sandbox is a Firecracker microVM. The storage layer is copy-on-write on NVMe, which is how the snapshots get cheap. Morph charges by written blocks, not allocated blocks, so a sandbox that does little writing is genuinely free-tier-compatible.
+          </p>
+          <p>
+            What I liked: the snapshot API is the cleanest expression of the &ldquo;agent as a process you can rewind&rdquo; idea. I have not seen this work elsewhere with the same UX.
+          </p>
+          <pre><code>{`const sb = await morph.create({ image: "ubuntu-22.04" })
+const checkpoint = await sb.snapshot()
+await sb.exec("rm -rf /etc")     // do something risky
+await sb.restore(checkpoint)     // undo`}</code></pre>
+          <p>
+            What bit me: the docs are still light, the SDK shape moves between minor versions, and I had a few sessions where snapshot restore took noticeably longer than the advertised 300 ms (closer to a second). Early product, real ideas.
+          </p>
+          <p>
+            <strong>Use it for:</strong> Iteration-heavy agent loops where rollback is part of the algorithm.
+          </p>
+
+          <h2>Vercel Sandbox</h2>
+          <p>
+            Vercel Sandbox is a Firecracker microVM service tightly bound to the Vercel platform. The session ceiling is 45 minutes — short, and it is short on purpose. The pitch is &ldquo;you have an AI feature in your Vercel app and you need to run a bit of generated code somewhere.&rdquo;
+          </p>
+          <p>
+            What I liked: per-active-CPU billing. Most sandbox time on a coding agent is the agent thinking, not the CPU computing. Vercel only charges you for the latter, which makes a 5-cent invocation actually cost a tenth of a cent. The free tier was generous enough that I never paid during my test.
+          </p>
+          <pre><code>{`import { Sandbox } from "@vercel/sandbox"
+
+const sb = await Sandbox.create({ runtime: "node22" })
+await sb.writeFiles([{ path: "index.js", content: "console.log('hi')" }])
+const out = await sb.runCommand({ cmd: "node", args: ["index.js"] })`}</code></pre>
+          <p>
+            What bit me: the 45-minute ceiling is hard. If your agent task is going to take an hour, you need to design for handoff. There is no GPU, no BYOC, and outside the Vercel platform the value proposition narrows a lot.
+          </p>
+          <p>
+            <strong>Use it for:</strong> Apps already on Vercel, short-lived per-request sandboxing, untrusted code execution from end-user input.
+          </p>
+
+          <h2>Docker Sandboxes (sbx)</h2>
+          <p>
+            <code>sbx</code> is the newcomer and the one that surprised me. Docker shipped it in March 2026 as a standalone CLI, no Docker Desktop required. Each sandbox is a microVM running on the local hypervisor — Apple Hypervisor on macOS, Hyper-V on Windows. Linux support is on the roadmap.
+          </p>
+          <p>
+            The killer feature is locality. The sandbox runs on your laptop. There is no remote API, no per-second billing, no rate limit. If you have ever burned an afternoon on cold-start latency or sandbox quota, you know how good that feels.
+          </p>
+          <pre><code>{`# install
+brew install docker/tap/sbx
+
+# log in
+sbx login
+
+# run claude code in a sandbox bound to the current directory
+cd ~/code/my-rust-repo
+sbx run claude`}</code></pre>
+          <p>
+            That last command is the whole experience. Claude Code starts inside a microVM, sees only the current directory, runs in <code>--dangerously-skip-permissions</code> mode by default, and cannot reach the rest of your filesystem. Network is policy-gated; you choose between <em>open</em>, <em>balanced</em>, and <em>locked down</em> on first login.
+          </p>
+          <p>
+            What I liked: it integrates with the agents people actually use. Out of the box: Claude Code, Codex, GitHub Copilot CLI, Gemini CLI, Kiro, OpenCode. The branch mode (<code>--branch</code>) creates a git worktree under <code>.sbx/</code> so the agent commits to its own branch, not your working tree.
+          </p>
+          <p>
+            What bit me: still experimental. The balanced network policy is missing common documentation domains, so a real coding session ends up needing &ldquo;open&rdquo; mode unless you maintain your own allow-list. macOS performance was great; Windows under Hyper-V was visibly slower for IO-heavy operations like a fresh <code>cargo build</code>.
+          </p>
+          <p>
+            <strong>Use it for:</strong> Local-first coding agent workflows. The right default unless you specifically need remote.
+          </p>
+
+          <h2>Side-by-side</h2>
+          <p>
+            Same workload, same agent, same Rust repo. Numbers are medians from ten runs each.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Runtime</th>
+                <th>Isolation</th>
+                <th>Cold start</th>
+                <th>Session cap</th>
+                <th>Persistence</th>
+                <th>Local-first</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>E2B</td><td>Firecracker</td><td>~180 ms</td><td>24 h</td><td>No</td><td>No</td></tr>
+              <tr><td>Daytona</td><td>Container</td><td>~95 ms</td><td>Unlimited</td><td>Yes</td><td>No</td></tr>
+              <tr><td>Modal</td><td>gVisor</td><td>~600 ms</td><td>Unlimited</td><td>Snapshots</td><td>No</td></tr>
+              <tr><td>Morph</td><td>Firecracker</td><td>~300 ms</td><td>Unlimited</td><td>Snapshots</td><td>No</td></tr>
+              <tr><td>Vercel</td><td>Firecracker</td><td>~250 ms</td><td>45 min</td><td>No</td><td>No</td></tr>
+              <tr><td>Docker sbx</td><td>microVM (local)</td><td>~1.2 s first / instant warm</td><td>Until you stop it</td><td>Yes</td><td>Yes</td></tr>
+            </tbody>
+          </table>
+          <p>
+            The cold-start number for sbx is misleading on first read. It is the slowest because the microVM provisions the first time you run a sandbox. After that, subsequent commands inside the sandbox run at native speed because there is no network round trip. The remote runtimes have a network hop on every operation that the local one does not.
+          </p>
+
+          <h2>How I actually pick</h2>
+          <p>
+            After two weeks of this, my decision tree is small.
+          </p>
+          <p>
+            <strong>If the agent runs on my laptop, sbx wins.</strong> Local microVM, no quota, integrates with the agents I already use, free. The first-time cold start is irrelevant once the image is cached.
+          </p>
+          <p>
+            <strong>If the agent runs in our infra and we need persistent sessions, Daytona wins.</strong> Long-lived workspaces, fast cold start, Computer Use if I ever need a browser inside a sandbox. The container isolation is acceptable for our trust model.
+          </p>
+          <p>
+            <strong>If the agent runs ephemerally as part of a request handler, Vercel Sandbox wins.</strong> Per-active-CPU billing, microVM, generous free tier, integrated with the platform we already deploy on.
+          </p>
+          <p>
+            <strong>If the agent is iterating with rollback as part of the algorithm, Morph wins.</strong> Nothing else has snapshot-and-restore as a first-class operation.
+          </p>
+          <p>
+            <strong>If the agent needs GPU, Modal wins.</strong> By default, by elimination. None of the others do GPU.
+          </p>
+          <p>
+            <strong>E2B</strong> is fine, but I have not found the workload it is the right answer to that one of the others does not also serve. It is the most polished SDK, and that matters if SDK ergonomics dominate your decision.
+          </p>
+
+          <h2>One thing nobody talks about</h2>
+          <p>
+            Every one of these runtimes does the &ldquo;agent runs in a box&rdquo; story well. None of them solves the second boundary that matters: the boundary between what the agent wrote and what reaches your main branch.
+          </p>
+          <p>
+            The microVM keeps the agent from <code>rm -rf</code>-ing your machine. It does not keep the agent from writing a subtly broken patch and pushing it to <code>main</code>. The same property that makes a YOLO agent fast — autonomous action, no human in the loop — means the output is unsupervised by definition. If that output reaches a shared branch without a human eye on it, the sandbox boundary did not save you, because the harm escaped through the legitimate output channel.
+          </p>
+          <p>
+            Every runtime I tested has some answer to this. <code>sbx</code> has <code>--branch</code>. Daytona has explicit workspace-to-branch mapping. The remote runtimes generally hand you a tarball and let you handle the git layer yourself. You should treat that handoff as the security boundary. The microVM is a precondition; the branch boundary is the actual control.
+          </p>
+
+          <h2>Where I landed</h2>
+          <p>
+            I run two sandboxes for two different jobs.
+          </p>
+          <p>
+            For local agent work, I use <code>sbx</code>. The latency is best, the integration with Claude Code is one command, and the cost is zero. The first day I switched, I noticed I was running the agent more aggressively because I knew the worst case was a wrecked sandbox, not a wrecked machine.
+          </p>
+          <p>
+            For our deployed agent that processes real customer requests, I use Vercel Sandbox. Per-active-CPU billing was the deciding factor — sandbox time on a coding agent is mostly waiting on the model, and I do not want to pay for that.
+          </p>
+          <p>
+            I will probably revisit this in three months. The space is moving fast — Zeroboot is claiming sub-millisecond cold starts via copy-on-write Firecracker forks, and Docker is adding Linux support to <code>sbx</code> later this year. If the comparisons change materially, I will write the followup.
+          </p>
+        </motion.div>
+      </article>
+    </main>
+  )
+}

--- a/frontend/src/app/blog/agent-sandbox-runtimes-tested/twitter-image.tsx
+++ b/frontend/src/app/blog/agent-sandbox-runtimes-tested/twitter-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'I Ran Six Agent Sandbox Runtimes Back to Back'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0a0a0a 0%, #1e293b 50%, #0a0a0a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(255,107,53,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(255,107,53,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(255,107,53,0.15)', border: '1px solid rgba(255,107,53,0.3)' }}>
+            <span style={{ color: '#FF6B35', fontSize: '16px', fontWeight: 600 }}>AI Agents</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(255,107,53,0.1)', border: '1px solid rgba(255,107,53,0.2)' }}>
+            <span style={{ color: '#FF6B35', fontSize: '16px', fontWeight: 600 }}>Sandboxes</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(255,107,53,0.1)', border: '1px solid rgba(255,107,53,0.2)' }}>
+            <span style={{ color: '#FF6B35', fontSize: '16px', fontWeight: 600 }}>microVM</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Six Agent Sandbox Runtimes,</h1>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: '8px 0 0 0', letterSpacing: '-0.02em' }}>Tested Back to Back</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>E2B &middot; Daytona &middot; Modal &middot; Morph &middot; Vercel &middot; Docker sbx</p>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>May 3, 2026 &middot; 16 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/blog/blog-data.ts
+++ b/frontend/src/app/blog/blog-data.ts
@@ -10,6 +10,33 @@ export interface BlogPost {
 
 export const blogPosts: BlogPost[] = [
   {
+    slug: 'content-addressed-memory-for-agents',
+    title: 'Your AI Agent’s Memory Is Probably Broken. Here Is Why.',
+    description: 'Random IDs duplicate facts on every re-import. Content-addressed IDs and reinforcement-on-write fix it in forty lines. Walkthrough with Letta, Mem0, and agentmemory.',
+    date: 'May 9, 2026',
+    readTime: '15 min read',
+    tags: ['AI Agents', 'Memory', 'Fundamentals'],
+    accentColor: '#3b82f6',
+  },
+  {
+    slug: 'agent-sandbox-runtimes-tested',
+    title: 'I Ran Six Agent Sandbox Runtimes Back to Back. Here Is What Actually Worked.',
+    description: 'E2B, Daytona, Modal, Morph, Vercel Sandbox, and Docker sbx — six microVM and gVisor runtimes for AI coding agents, tested on the same workload. Cold-start times, isolation models, persistence, network policies.',
+    date: 'May 3, 2026',
+    readTime: '16 min read',
+    tags: ['AI Agents', 'Sandboxes', 'microVM'],
+    accentColor: '#FF6B35',
+  },
+  {
+    slug: 'three-primitives-replace-fifty-sdks',
+    title: 'Three Primitives Are Enough: Rebuilding Backends Without Fifty SDKs',
+    description: 'Workers, functions, triggers — a small primitive set is collapsing the queue/cron/pubsub/HTTP/state/stream stack. The case, the code, and where it breaks.',
+    date: 'April 26, 2026',
+    readTime: '14 min read',
+    tags: ['Backend', 'Architecture', 'Fundamentals'],
+    accentColor: '#f3f724',
+  },
+  {
     slug: 'webmcp-chrome-ai-agents',
     title: 'WebMCP: Chrome Just Turned Every Website Into an API for AI Agents',
     description: 'Google and Microsoft shipped WebMCP in Chrome 146 — a W3C standard that lets websites expose structured tools to AI agents. 89% fewer tokens than screenshots, 980 GitHub stars in 48 hours.',

--- a/frontend/src/app/blog/content-addressed-memory-for-agents/layout.tsx
+++ b/frontend/src/app/blog/content-addressed-memory-for-agents/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Your AI Agent&apos;s Memory Is Probably Broken. Here Is Why.',
+  description: 'Most agent memory layers re-create the same fact six times when you re-import the source. Content-addressed IDs fix it. A walk through the failure mode, the fingerprint pattern, and how Letta, Mem0, and the open-source memory layer agentmemory each handle it.',
+  alternates: { canonical: '/blog/content-addressed-memory-for-agents' },
+  openGraph: {
+    title: 'Your AI Agent&apos;s Memory Is Probably Broken. Here Is Why.',
+    description: 'Random IDs duplicate facts on every re-import. Content-addressed memory deduplicates and reinforces. Walkthrough with Letta, Mem0, and agentmemory.',
+    type: 'article',
+    url: 'https://learndevrel.com/blog/content-addressed-memory-for-agents',
+    siteName: 'DevRel Guide',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Your AI Agent&apos;s Memory Is Probably Broken',
+    description: 'Random IDs duplicate facts on every re-import. Content-addressed memory deduplicates and reinforces.',
+  },
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/frontend/src/app/blog/content-addressed-memory-for-agents/opengraph-image.tsx
+++ b/frontend/src/app/blog/content-addressed-memory-for-agents/opengraph-image.tsx
@@ -23,7 +23,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
-          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Your Agent&apos;s Memory</h1>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Your Agent's Memory</h1>
           <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: '8px 0 0 0', letterSpacing: '-0.02em' }}>Is Probably Broken</h1>
           <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Content-addressed IDs, reinforcement-on-write, and forty lines of code.</p>
         </div>

--- a/frontend/src/app/blog/content-addressed-memory-for-agents/opengraph-image.tsx
+++ b/frontend/src/app/blog/content-addressed-memory-for-agents/opengraph-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Your AI Agent\'s Memory Is Probably Broken. Here Is Why.'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(59,130,246,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(59,130,246,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(59,130,246,0.15)', border: '1px solid rgba(59,130,246,0.3)' }}>
+            <span style={{ color: '#60a5fa', fontSize: '16px', fontWeight: 600 }}>AI Agents</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(59,130,246,0.1)', border: '1px solid rgba(59,130,246,0.2)' }}>
+            <span style={{ color: '#60a5fa', fontSize: '16px', fontWeight: 600 }}>Memory</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(59,130,246,0.1)', border: '1px solid rgba(59,130,246,0.2)' }}>
+            <span style={{ color: '#60a5fa', fontSize: '16px', fontWeight: 600 }}>Fundamentals</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Your Agent&apos;s Memory</h1>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: '8px 0 0 0', letterSpacing: '-0.02em' }}>Is Probably Broken</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Content-addressed IDs, reinforcement-on-write, and forty lines of code.</p>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>May 9, 2026 &middot; 15 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/blog/content-addressed-memory-for-agents/page.tsx
+++ b/frontend/src/app/blog/content-addressed-memory-for-agents/page.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+export default function ContentAddressedMemoryBlog() {
+  return (
+    <main className="min-h-screen bg-background">
+      <article className="container mx-auto px-4 py-16 max-w-3xl">
+        <Link href="/blog" className="inline-flex items-center gap-2 text-muted-foreground hover:text-secondary transition-colors mb-8">
+          <ArrowLeft className="h-4 w-4" /> Back to Blog
+        </Link>
+
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+          <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+            Your AI Agent&apos;s Memory Is Probably Broken. Here Is Why.
+          </h1>
+          <p className="text-muted-foreground mb-8">By Rohit Ghumare &bull; May 9, 2026 &bull; 15 min read</p>
+        </motion.div>
+
+        <motion.div
+          className="prose prose-invert max-w-none
+            prose-headings:text-foreground prose-p:text-muted-foreground
+            prose-a:text-secondary prose-strong:text-foreground
+            prose-blockquote:border-secondary prose-blockquote:text-muted-foreground
+            prose-th:text-foreground prose-td:text-muted-foreground
+            prose-li:text-muted-foreground
+            prose-code:text-secondary prose-pre:bg-muted prose-pre:border prose-pre:border-border"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2 }}
+        >
+          <p>
+            I have an agent that ingests my GitHub stars every morning and turns each repo description into a memory. It is supposed to give the agent context about what I have been reading. After a month of running it, the memory store had 2,400 entries. I had starred about 60 repos in that time.
+          </p>
+          <p>
+            Forty entries per repo. Same content, different IDs.
+          </p>
+          <p>
+            The memory layer was doing its job exactly as designed. Every time the cron ran, it re-imported every star, generated a fresh UUID for each one, and wrote it. Forty mornings, forty new memories per repo. The retrieval layer kept fishing out duplicate copies of the same fact, occasionally with stale variations. The agent started treating my memory store as untrustworthy and stopped consulting it.
+          </p>
+          <p>
+            This is the most common bug I see in production agent memory layers. It has a name and a fix. The bug is non-content-addressed identity. The fix is fingerprint IDs and reinforcement-on-write.
+          </p>
+          <p>
+            This post walks through the failure mode in detail, then through the three popular memory layers — Letta, Mem0, and the open-source <code>agentmemory</code> — and how each one does or does not solve it. If you maintain an agent in production, the fix takes about an hour and removes a class of bugs you may not have noticed.
+          </p>
+
+          <h2>The shape of the bug</h2>
+          <p>
+            Agent memory is stored as records. A record has an ID, some content, and metadata. Most memory APIs look like this:
+          </p>
+          <pre><code>{`memory.remember({
+  content: "Rohit starred openclawai/openclaw on 2026-04-30",
+  tags: ["github", "stars"],
+})`}</code></pre>
+          <p>
+            Behind the scenes, the memory layer generates an ID. Almost universally, that ID is a UUID or a database autoincrement — a value that has nothing to do with the content. Two calls with identical content produce two records with different IDs. The system has no way to tell they are the same fact.
+          </p>
+          <p>
+            This is fine if you only write each fact once. It is broken if your input source is replayable. Cron jobs are replayable. Webhook re-deliveries are replayable. Restarts are replayable. Anything that can run twice on the same input will produce duplicates.
+          </p>
+          <p>
+            And almost everything in a real agent stack is replayable. Re-imports happen because:
+          </p>
+          <ul>
+            <li>A scheduled job re-fetches the same source every day.</li>
+            <li>The agent crashes, restarts, and re-processes the queue.</li>
+            <li>You change the prompt, want to re-run on existing data, and re-emit memory writes.</li>
+            <li>You backfill from an export.</li>
+          </ul>
+          <p>
+            By the time the system has been running for a month, the duplicate count is usually two orders of magnitude above the unique-fact count, and the retrieval quality is wrecked.
+          </p>
+
+          <h2>Why retrieval breaks first</h2>
+          <p>
+            You might think duplicates are a storage problem, not a quality problem. Disk is cheap. Just leave them there.
+          </p>
+          <p>
+            The reason this argument fails is that retrieval ranks by similarity, not uniqueness. When you ask &ldquo;what has Rohit been reading lately,&rdquo; the search returns the top-k records by embedding distance. If forty of those records say the same thing, your top-10 result list is two unique facts and eight copies. The agent reads ten records and walks away with two facts. Recall just collapsed by 80%.
+          </p>
+          <p>
+            Worse, embeddings are not perfectly stable across model versions. The forty copies of &ldquo;Rohit starred openclaw&rdquo; will have forty subtly different embeddings if they were written across an embedding-model upgrade. Some will rank higher than the actual fact you want. Now the duplicates are not just noise; they are pushing the real facts out of the result set.
+          </p>
+          <p>
+            Memory staleness compounds this. Mem0&apos;s research notes that detecting when a high-relevance memory has gone stale is an open problem. With duplicates, even the &ldquo;current&rdquo; version of a fact has to compete with thirty old versions for retrieval rank. The decay layer can only do so much.
+          </p>
+
+          <h2>The fix: content-addressed IDs</h2>
+          <p>
+            The fix is small. It is one of the oldest tricks in distributed systems, and it is the same trick git uses.
+          </p>
+          <p>
+            For any fact derived from an external source you can re-fetch, the ID is a fingerprint of the content. Same content, same ID. Two writes with the same fingerprint are the same memory by definition; the second write is not a duplicate, it is a touch on the existing record.
+          </p>
+          <p>
+            In the simplest implementation, the fingerprint is a SHA-256 of the canonical fact string:
+          </p>
+          <pre><code>{`function fingerprintId(facts: { source: string; key: string; value: string }) {
+  const canonical = ` + '`${facts.source}::${facts.key}::${facts.value}`' + `
+  return "fp_" + sha256(canonical).slice(0, 24)
+}`}</code></pre>
+          <p>
+            For a richer implementation you also strip whitespace, lowercase identifiers, sort tags, and version the schema so a future change does not silently fork all your IDs.
+          </p>
+          <p>
+            On write, the API is now <em>upsert</em> instead of <em>insert</em>:
+          </p>
+          <pre><code>{`memory.upsert({
+  id: fingerprintId({
+    source: "github_stars",
+    key: "openclawai/openclaw",
+    value: "starred",
+  }),
+  content: "Rohit starred openclawai/openclaw on 2026-04-30",
+  tags: ["github", "stars"],
+})`}</code></pre>
+          <p>
+            Two calls collapse to one record. Forty calls collapse to one record. The cron job is now idempotent for free.
+          </p>
+
+          <h2>Reinforcement: turning a bug into a feature</h2>
+          <p>
+            Here is the part that surprised me. Once you have content-addressed IDs and your writes are upserts, you can do something the original system could not: count the writes.
+          </p>
+          <p>
+            Every time a re-import touches an existing fact, the upsert is a signal that the fact is still true in the source. That is information you would not otherwise have. The stored record can carry a <code>last_seen</code> timestamp, a <code>seen_count</code>, and a <code>first_seen</code>. Now you can:
+          </p>
+          <ul>
+            <li>Decay records the source has stopped emitting (the unstar case).</li>
+            <li>Boost retrieval rank by reinforcement, not just recency.</li>
+            <li>Detect freshness drift — a fact whose <code>last_seen</code> is two months stale is a candidate for review.</li>
+          </ul>
+          <p>
+            The upsert path is shaped like this:
+          </p>
+          <pre><code>{`function upsert(record: Record) {
+  const existing = store.get(record.id)
+  if (existing) {
+    existing.last_seen = now()
+    existing.seen_count += 1
+    existing.content = record.content // refresh
+    return store.put(existing)
+  }
+  return store.put({
+    ...record,
+    first_seen: now(),
+    last_seen: now(),
+    seen_count: 1,
+  })
+}`}</code></pre>
+          <p>
+            Twenty lines of code take you from &ldquo;duplicates everywhere&rdquo; to &ldquo;reinforcement signal as a first-class field.&rdquo; The downstream retrieval layer can use <code>seen_count</code> in the rerank step.
+          </p>
+
+          <h2>How the popular layers handle this</h2>
+          <p>
+            I went back through three memory layers I have used in the last six months and looked at how each one handles auto-derived records.
+          </p>
+
+          <h3>Letta (formerly MemGPT)</h3>
+          <p>
+            Letta is the most explicit about memory as a first-class component. Its model has core memory blocks and archival memory, with the agent using tools to manage what is paged in and out. Records have UUIDs by default.
+          </p>
+          <p>
+            Letta&apos;s &ldquo;memory blocks&rdquo; are designed to be edited in place — the agent uses <code>core_memory_replace</code> and <code>core_memory_append</code> tools, which give you something like idempotency for the in-context portion of memory. But for archival memory, which is the part you write to from cron jobs, the IDs are not content-derived. You have to layer the fingerprint pattern on top.
+          </p>
+          <p>
+            The fix in Letta land is to compute the fingerprint client-side and store it as a key in the metadata. The retrieval layer can then dedupe before returning. It works, but it is not the default and the docs do not push you toward it.
+          </p>
+
+          <h3>Mem0</h3>
+          <p>
+            Mem0&apos;s architecture is built around a fact-extraction pipeline that explicitly tries to deduplicate at extract time. From the Mem0 paper: the pipeline accepts a 6-percentage-point accuracy trade in exchange for 91% lower p95 latency and 90% fewer tokens, partly by aggressive consolidation.
+          </p>
+          <p>
+            That gives you deduplication for free in the &ldquo;agent observed two facts about the user across two conversations&rdquo; case. It does not give you deduplication for the &ldquo;cron re-imported the same source&rdquo; case, because the extractor does not know that yesterday&apos;s import is the same source as today&apos;s.
+          </p>
+          <p>
+            The fix in Mem0 land is to use the <code>metadata.user_id</code> + a deterministic key for source-keyed records, and to delete-then-write rather than blind insert. The Mem0 SDK exposes this; it just is not the path the docs walk you down.
+          </p>
+
+          <h3>agentmemory</h3>
+          <p>
+            <code>agentmemory</code> is the open-source memory layer I have been working on. It runs on the iii engine I wrote about in the first post in this series. It does content-addressed IDs as the default for any auto-derived record, with the upsert-and-reinforce path baked into the API.
+          </p>
+          <pre><code>{`import { remember } from "@agentmemory/sdk"
+
+await remember({
+  fingerprintId: {
+    source: "github_stars",
+    key: "openclawai/openclaw",
+    value: "starred",
+  },
+  content: "Rohit starred openclawai/openclaw on 2026-04-30",
+  tags: ["github", "stars"],
+})`}</code></pre>
+          <p>
+            Pass <code>fingerprintId</code> instead of letting the SDK generate one, and the write becomes idempotent. The store carries <code>first_seen</code>, <code>last_seen</code>, and <code>seen_count</code> automatically. The retrieval layer rerank already considers <code>seen_count</code>.
+          </p>
+          <p>
+            I am not pitching the package; I am pitching the pattern. If you do not want another dependency, the same pattern is forty lines on top of any KV store. The point is that auto-derived records are a different category of memory from agent-observed ones, and they want a different write path.
+          </p>
+
+          <h2>Where the pattern does not apply</h2>
+          <p>
+            Content-addressed IDs are not the right answer for everything.
+          </p>
+          <p>
+            <strong>Conversational observations.</strong> When the agent infers something from a chat (&ldquo;the user prefers terse responses&rdquo;), the fingerprint is harder to compute because the same observation can be expressed many ways. You want fact extraction with semantic clustering — what Mem0 does — not content-addressed IDs. Use both. They solve different parts of the problem.
+          </p>
+          <p>
+            <strong>Time-series facts.</strong> A weather observation at 14:00 today and at 14:00 tomorrow are different records, even if the temperature happens to be the same. Include time in the fingerprint or do not use a fingerprint at all.
+          </p>
+          <p>
+            <strong>Ground-truth corrections.</strong> If the agent learns &ldquo;the previous fact was wrong, the new one is correct,&rdquo; you want a write that tombstones the old record, not an upsert that overwrites it. Track corrections explicitly.
+          </p>
+
+          <h2>The thing I keep coming back to</h2>
+          <p>
+            I think this matters more than the framing suggests, because the duplicate-on-replay bug is the kind of thing that does not show up in any benchmark. The benchmarks all use a fixed corpus. They measure recall on a snapshot. Production is a stream, and a stream that is a few months old is a different organism from a fresh corpus.
+          </p>
+          <p>
+            The memory layer that performs well on LongMemEval today might fail in your production after sixty cron runs because the writes did not have content-addressed IDs and the retrieval layer is now picking duplicates. The benchmark cannot see this.
+          </p>
+          <p>
+            The fix is small enough that you should just do it. Compute fingerprints for any record that comes from a source you might re-import. Use upserts. Track reinforcement. Watch the duplicate ratio in your store and make it part of your dashboards.
+          </p>
+          <p>
+            Memory is the part of an agent system that compounds. A chat handler can be replaced. A retrieval index can be rebuilt. A memory store with a year of corrupted writes is the only thing that does not get better with effort. Get the write path right.
+          </p>
+
+          <h2>What I would do tomorrow</h2>
+          <p>
+            If I were starting an agent project today and the memory layer was a TODO, I would do this:
+          </p>
+          <ol>
+            <li>Use whatever memory layer you like for conversational observations. Mem0, Letta, vector store with a thin wrapper — they all work fine for the &ldquo;agent inferred this from chat&rdquo; case.</li>
+            <li>Wrap it with a second write path for auto-derived records. That path takes a fingerprint ID and does upsert-and-reinforce. Forty lines of code.</li>
+            <li>Add a <code>seen_count</code> tiebreaker to your retrieval rerank. Free signal once you have it.</li>
+            <li>Track duplicate ratio (records sharing the same fingerprint) as a metric. It should be near zero. If it is climbing, your write path has regressed.</li>
+          </ol>
+          <p>
+            That is it. The whole pattern fits in an afternoon. The recall improvement is large enough that you will notice it in agent quality the same week.
+          </p>
+          <p>
+            I have one more post coming in this series. The next one looks at how an agent should choose between writing to memory and writing to durable state — the line between &ldquo;remember this&rdquo; and &ldquo;persist this&rdquo; turns out to be subtler than I thought, and I have changed my mind on it twice in the last two months. If you want the followup, the blog index has the rest.
+          </p>
+        </motion.div>
+      </article>
+    </main>
+  )
+}

--- a/frontend/src/app/blog/content-addressed-memory-for-agents/twitter-image.tsx
+++ b/frontend/src/app/blog/content-addressed-memory-for-agents/twitter-image.tsx
@@ -23,7 +23,7 @@ export default function Image() {
           </div>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
-          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Your Agent&apos;s Memory</h1>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Your Agent's Memory</h1>
           <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: '8px 0 0 0', letterSpacing: '-0.02em' }}>Is Probably Broken</h1>
           <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Content-addressed IDs, reinforcement-on-write, and forty lines of code.</p>
         </div>

--- a/frontend/src/app/blog/content-addressed-memory-for-agents/twitter-image.tsx
+++ b/frontend/src/app/blog/content-addressed-memory-for-agents/twitter-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Your AI Agent\'s Memory Is Probably Broken. Here Is Why.'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(59,130,246,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(59,130,246,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(59,130,246,0.15)', border: '1px solid rgba(59,130,246,0.3)' }}>
+            <span style={{ color: '#60a5fa', fontSize: '16px', fontWeight: 600 }}>AI Agents</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(59,130,246,0.1)', border: '1px solid rgba(59,130,246,0.2)' }}>
+            <span style={{ color: '#60a5fa', fontSize: '16px', fontWeight: 600 }}>Memory</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(59,130,246,0.1)', border: '1px solid rgba(59,130,246,0.2)' }}>
+            <span style={{ color: '#60a5fa', fontSize: '16px', fontWeight: 600 }}>Fundamentals</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Your Agent&apos;s Memory</h1>
+          <h1 style={{ color: '#f1f5f9', fontSize: '50px', fontWeight: 700, lineHeight: 1.15, margin: '8px 0 0 0', letterSpacing: '-0.02em' }}>Is Probably Broken</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Content-addressed IDs, reinforcement-on-write, and forty lines of code.</p>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>May 9, 2026 &middot; 15 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/blog/three-primitives-replace-fifty-sdks/layout.tsx
+++ b/frontend/src/app/blog/three-primitives-replace-fifty-sdks/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Three Primitives Are Enough: Rebuilding Backends Without Fifty SDKs',
+  description: 'Modern backends pull in queues, cron schedulers, pub/sub, HTTP frameworks, state stores, and stream brokers — each with its own SDK and failure mode. A small but growing camp argues that three primitives cover all of it. Here is the case, with code.',
+  alternates: { canonical: '/blog/three-primitives-replace-fifty-sdks' },
+  openGraph: {
+    title: 'Three Primitives Are Enough: Rebuilding Backends Without Fifty SDKs',
+    description: 'Workers, functions, triggers — why a tiny primitive set is collapsing the queue/cron/pubsub/HTTP/state/stream stack.',
+    type: 'article',
+    url: 'https://learndevrel.com/blog/three-primitives-replace-fifty-sdks',
+    siteName: 'DevRel Guide',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Three Primitives Are Enough',
+    description: 'Workers, functions, triggers — why a tiny primitive set replaces the queue/cron/pubsub/HTTP/state/stream stack.',
+  },
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/frontend/src/app/blog/three-primitives-replace-fifty-sdks/opengraph-image.tsx
+++ b/frontend/src/app/blog/three-primitives-replace-fifty-sdks/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Three Primitives Are Enough: Rebuilding Backends Without Fifty SDKs'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(243,247,36,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(243,247,36,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(243,247,36,0.15)', border: '1px solid rgba(243,247,36,0.3)' }}>
+            <span style={{ color: '#f3f724', fontSize: '16px', fontWeight: 600 }}>Backend</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(243,247,36,0.1)', border: '1px solid rgba(243,247,36,0.2)' }}>
+            <span style={{ color: '#f3f724', fontSize: '16px', fontWeight: 600 }}>Architecture</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(243,247,36,0.1)', border: '1px solid rgba(243,247,36,0.2)' }}>
+            <span style={{ color: '#f3f724', fontSize: '16px', fontWeight: 600 }}>Fundamentals</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '52px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Three Primitives Are Enough</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Workers, functions, triggers — and the SDK explosion stops.</p>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>April 26, 2026 &middot; 14 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/blog/three-primitives-replace-fifty-sdks/page.tsx
+++ b/frontend/src/app/blog/three-primitives-replace-fifty-sdks/page.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+export default function ThreePrimitivesBlog() {
+  return (
+    <main className="min-h-screen bg-background">
+      <article className="container mx-auto px-4 py-16 max-w-3xl">
+        <Link href="/blog" className="inline-flex items-center gap-2 text-muted-foreground hover:text-secondary transition-colors mb-8">
+          <ArrowLeft className="h-4 w-4" /> Back to Blog
+        </Link>
+
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+          <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+            Three Primitives Are Enough: Rebuilding Backends Without Fifty SDKs
+          </h1>
+          <p className="text-muted-foreground mb-8">By Rohit Ghumare &bull; April 26, 2026 &bull; 14 min read</p>
+        </motion.div>
+
+        <motion.div
+          className="prose prose-invert max-w-none
+            prose-headings:text-foreground prose-p:text-muted-foreground
+            prose-a:text-secondary prose-strong:text-foreground
+            prose-blockquote:border-secondary prose-blockquote:text-muted-foreground
+            prose-th:text-foreground prose-td:text-muted-foreground
+            prose-li:text-muted-foreground
+            prose-code:text-secondary prose-pre:bg-muted prose-pre:border prose-pre:border-border"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2 }}
+        >
+          <p>
+            I have been writing backend services for a decade. I want to talk about the moment I realised most of the SDK surface area I deal with every day is accidental complexity, not the work.
+          </p>
+          <p>
+            Here is the inventory I pulled from a small production service I shipped last quarter. It is not a big system. It does one thing well. Look at the dependency list:
+          </p>
+          <pre><code>{`bullmq          // queue
+node-cron       // schedules
+ioredis         // pub/sub + cache
+express         // HTTP
+prisma          // state
+ws              // streams
+pino            // logs
+@opentelemetry  // traces`}</code></pre>
+          <p>
+            Eight packages. Eight failure modes. Eight different ways to express &ldquo;run this code when something happens.&rdquo; The HTTP handler enqueues a job. The job worker reads from Postgres, writes to Redis, publishes a pub/sub event, schedules a follow-up via cron, opens a websocket, and emits a span. Every hop is a different vocabulary.
+          </p>
+          <p>
+            Most of that is not the work. The work is one function that processes one event. The rest is plumbing the runtime did not give me.
+          </p>
+          <p>
+            A small but growing camp of engineers is arguing that three primitives are enough to express all of it. I want to walk through the argument, show the code, and then talk about where it breaks.
+          </p>
+
+          <h2>The shape of the claim</h2>
+          <p>
+            The claim is that any backend system can be expressed with three nouns:
+          </p>
+          <ol>
+            <li><strong>Worker.</strong> A long-running process. It is a unit of deployment and resource isolation. It owns a piece of the application.</li>
+            <li><strong>Function.</strong> A piece of code inside a worker. It takes a typed input, does work, returns a typed output. The runtime can call it for any reason.</li>
+            <li><strong>Trigger.</strong> A reason the runtime calls a function. HTTP request, scheduled time, queue message, file change, database write. The trigger is data; the function does not care where the data came from.</li>
+          </ol>
+          <p>
+            Once you accept that decomposition, the SDK explosion collapses. A queue is a trigger. Cron is a trigger. HTTP is a trigger. Pub/sub is a trigger. A websocket message is a trigger. State changes can be a trigger. They are all <em>reasons to call a function</em>, which is the only thing the application code actually cares about.
+          </p>
+          <p>
+            The runtime owns retries, timeouts, observability, persistence, and fan-out. The application owns the function body. That is the entire deal.
+          </p>
+
+          <h2>What the code actually looks like</h2>
+          <p>
+            I have been writing services in this style for the last three months on a runtime called iii (three i&apos;s — short for &ldquo;interoperable invocation interface&rdquo;). The Rust SDK is the cleanest expression of the idea, so I will use it for the example. The Node and Python SDKs map one-to-one.
+          </p>
+          <p>
+            Here is a complete worker that exposes an HTTP endpoint, runs a cron job, and reacts to a queue message. One file, no extra services:
+          </p>
+          <pre><code>{`use iii_sdk::{Client, RegisterFunction, RegisterTrigger, IIIError};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), IIIError> {
+    let client = Client::connect("ws://localhost:49134").await?;
+
+    client.register_worker("orders").await?;
+
+    client.register_function(
+        RegisterFunction::new_async("orders::handle", |ctx, input| async move {
+            let order_id = input["order_id"].as_str().unwrap();
+            ctx.state().update("orders", order_id, json!({
+                "status": "received",
+                "received_at": ctx.now(),
+            })).await?;
+            Ok(json!({ "ok": true }))
+        }),
+    ).await?;
+
+    client.register_trigger(RegisterTrigger::http()
+        .method("POST")
+        .api_path("orders/new")
+        .function("orders::handle")).await?;
+
+    client.register_trigger(RegisterTrigger::cron()
+        .schedule("*/5 * * * *")
+        .function("orders::reconcile")).await?;
+
+    client.register_trigger(RegisterTrigger::queue("dead-letters")
+        .function("orders::dlq")).await?;
+
+    client.run().await
+}`}</code></pre>
+          <p>
+            Read the file. Three triggers. One function shown, two more by name. Zero lines about retries, persistence, transport, or observability. The runtime takes those.
+          </p>
+          <p>
+            If you want a queue, you write <code>RegisterTrigger::queue(name)</code>. The runtime persists the messages. If you want cron, you write <code>RegisterTrigger::cron().schedule(expr)</code>. The runtime enforces the schedule across restarts. If you want HTTP, you write <code>RegisterTrigger::http()</code>. The runtime owns the listener.
+          </p>
+          <p>
+            There is no <code>bullmq</code>. There is no <code>node-cron</code>. There is no <code>express</code>. The runtime exposes a single async API and a transport, and the application is shaped around triggers and functions.
+          </p>
+
+          <h2>Why this is not just another framework</h2>
+          <p>
+            I want to be careful here, because the framework graveyard is large.
+          </p>
+          <p>
+            Inngest, Temporal, Restate, Cloudflare Workers, AWS Step Functions, Google Cloud Run jobs, Vercel Functions — all of them gesture at this idea. Many of them implement parts of it well. So why do I keep coming back to the three-primitive framing instead of any of them?
+          </p>
+          <p>
+            Two reasons.
+          </p>
+          <p>
+            <strong>Reason one: the framing is the product.</strong> Most workflow engines treat the workflow as the unit of abstraction — a DAG, a state machine, a saga. The function is hidden inside the workflow. That is fine for batch pipelines. It is bad for the messy reality of an application, where most of the code is not a workflow at all but a single function that handles one event and returns. When the framework forces you to express everything as a workflow, you end up writing one-step workflows everywhere, and the abstraction tax shows up in the call graph and the observability surface.
+          </p>
+          <p>
+            The three-primitive model takes the opposite stance. The function is the unit. Workflows are emergent — you get them by chaining functions through triggers. If you want a saga, you write functions and let the runtime fan them out. The DAG is implicit in the trigger graph, not authored.
+          </p>
+          <p>
+            <strong>Reason two: the runtime is small enough to host yourself.</strong> Temporal needs a Postgres cluster, a history service, a matching service, and a frontend. Cloudflare Workers is a managed platform. Inngest pushes you toward their cloud. The three-primitive runtime I have been working with is a single Rust binary that opens one websocket port. Workers connect over WebSocket and register their functions and triggers. State, queues, and streams are libraries that workers register the same way as anything else.
+          </p>
+          <p>
+            You can run the whole thing on a laptop, in a Docker container, or on a $5 VPS. There is no control plane. There is no &ldquo;platform&rdquo; in the marketing sense. There is a binary, a config file, and your workers.
+          </p>
+
+          <h2>What a queue actually is</h2>
+          <p>
+            Let me make the collapse concrete with one primitive — the queue.
+          </p>
+          <p>
+            In the conventional stack, a queue is a service. It is BullMQ on Redis, or RabbitMQ, or SQS, or Kafka with a consumer group. It has its own SDK, its own failure modes, and its own observability story. The application calls into the SDK to enqueue and to consume.
+          </p>
+          <p>
+            In the three-primitive model, a queue is a worker that registers two functions:
+          </p>
+          <pre><code>{`queue::push    // append a message to a named queue
+queue::pop     // pop a message and route it to a target function`}</code></pre>
+          <p>
+            That is it. The worker stores messages on disk, exposes a queue trigger type, and handles fan-out. Other workers register triggers like <code>queue::pop("dead-letters")</code> and the runtime calls them when messages arrive. To enqueue, you call <code>iii.trigger(&quot;queue::push&quot;, &#123; queue: &quot;dead-letters&quot;, body &#125;)</code>. No new vocabulary.
+          </p>
+          <p>
+            The same shape works for cron, pub/sub, state, and streams. Each one is a worker. Each one registers a small set of functions. Each one exposes a trigger type. The runtime stitches them together over the same transport that any other worker uses.
+          </p>
+          <p>
+            That uniformity is the win. You do not learn a new SDK to add cron. You add a worker called <code>iii-cron</code>, and now you have a cron trigger. You add a worker called <code>iii-pubsub</code>, and now you have pub/sub. The capability surface of your application is the union of the workers you started, and every worker speaks the same protocol.
+          </p>
+
+          <h2>What this actually buys you</h2>
+          <p>
+            I have been counting concrete wins on a real production service over the last three months. Three stand out.
+          </p>
+          <p>
+            <strong>One transport, one log, one trace.</strong> Every function call goes through the same WebSocket. There is one place to attach an observer. OpenTelemetry traces span across HTTP triggers, queue handlers, cron jobs, and state writes without me writing a single propagation header. When something goes wrong, I read one trace, not seven.
+          </p>
+          <p>
+            <strong>Migration becomes a worker swap.</strong> I started with the in-process state worker. When I needed durability, I swapped it for a Postgres-backed worker. The application code did not change. <code>ctx.state().update(...)</code> is a function call; the implementation lives in a worker; swapping workers swaps storage. The same shape lets me move from a local queue to a Redis-backed one without touching the call sites.
+          </p>
+          <p>
+            <strong>Local development is the same as production.</strong> I run the same binary on my laptop and on the server. There is no &ldquo;local development override&rdquo; or &ldquo;staging emulator.&rdquo; If a test passes locally, it passes in production for the same reasons. This is what I always wanted from serverless and never got, because the serverless platforms make local development a fiction.
+          </p>
+
+          <h2>Where it breaks (be honest)</h2>
+          <p>
+            I would not be doing this honestly if I did not call out the rough edges.
+          </p>
+          <p>
+            <strong>Cold-start workers.</strong> Workers connect over WebSocket. If the runtime restarts, every worker reconnects. In a heavily-loaded system that takes seconds. The runtime needs sticky reconnection logic; right now you write it. This is a real operational tax.
+          </p>
+          <p>
+            <strong>Macro DAGs are still worth authoring.</strong> The three-primitive model says workflows are emergent. That is true for two-or-three-step chains. For a fifteen-step billing pipeline with compensation logic, you still want to author the DAG explicitly. The runtime gives you the function call primitive; you still have to write the orchestrator function. A higher-level workflow library on top is the right answer, and it does not exist yet for this particular runtime.
+          </p>
+          <p>
+            <strong>Ecosystem gravity.</strong> When something is broken in BullMQ, half the internet has hit it before you. When something is broken in a young runtime, you read the source. I have read more Rust source in the last three months than in the prior three years. That is fine for me; it would not be fine for everyone on a team.
+          </p>
+          <p>
+            <strong>The metaphor leaks at the wire.</strong> The runtime hides protocol details well, until you need to integrate with something the runtime does not have a worker for. Then you write the worker. That is the right architecture, but it means the bus stops at the runtime — anything outside has to be marshalled through a custom adapter you maintain.
+          </p>
+
+          <h2>How to think about whether this is for you</h2>
+          <p>
+            Three questions decide it.
+          </p>
+          <p>
+            <strong>Is most of your code a function that handles one event?</strong> If yes, the three-primitive model is going to feel obvious. If your code is mostly orchestration over many systems, you want a workflow engine, not a function runtime.
+          </p>
+          <p>
+            <strong>Are you spending more than a third of your time on integration plumbing?</strong> SDK glue, adapter code, retry logic, observability wiring — if these dominate your hours, the framing collapses that work to zero. If you are mostly writing business logic in one language against one database, the gain is smaller.
+          </p>
+          <p>
+            <strong>Do you control your hosting?</strong> The runtime is a binary. You run it. If you have a platform team that wants serverless functions on a managed control plane, this will feel like going backwards. If you are happy with a long-lived process you operate, this is liberating.
+          </p>
+          <p>
+            For me, the answer to all three is yes, and I have not gone back.
+          </p>
+
+          <h2>Try it in five minutes</h2>
+          <p>
+            If you want to play with the runtime I have been describing, the install is one line:
+          </p>
+          <pre><code>{`curl -fsSL https://install.iii.dev/iii/main/install.sh | sh`}</code></pre>
+          <p>
+            Then start the engine, scaffold a worker, and call your first function:
+          </p>
+          <pre><code>{`iii engine start
+
+# in another terminal
+iii worker new hello --rust
+cd hello
+cargo run
+
+# in a third terminal
+iii fn call hello::greet --input '{"name":"Rohit"}'`}</code></pre>
+          <p>
+            The hello worker registers one function and one HTTP trigger. The CLI calls the function over the same transport an HTTP request would have used. There is no second &ldquo;serve&rdquo; mode.
+          </p>
+
+          <h2>Closing</h2>
+          <p>
+            The argument is not that three primitives are the only way to write a backend. Plenty of systems get built on the SDK-per-need model and ship just fine.
+          </p>
+          <p>
+            The argument is that the SDK explosion is not load-bearing. Most of it is plumbing, and plumbing should be a runtime concern, not an application concern. When you commit to a small primitive set and let the runtime carry the rest, the application code shrinks to roughly what the work actually is. Reading a service becomes reading the function bodies and the trigger registrations. Everything else is gone.
+          </p>
+          <p>
+            I am writing more posts in this series — the next one looks at how I picked an agent sandbox runtime to give my coding agent a place to live, with the same three-primitive framing for context. If you want to follow along, the blog index has the rest.
+          </p>
+        </motion.div>
+      </article>
+    </main>
+  )
+}

--- a/frontend/src/app/blog/three-primitives-replace-fifty-sdks/page.tsx
+++ b/frontend/src/app/blog/three-primitives-replace-fifty-sdks/page.tsx
@@ -167,7 +167,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
           <pre><code>{`queue::push    // append a message to a named queue
 queue::pop     // pop a message and route it to a target function`}</code></pre>
           <p>
-            That is it. The worker stores messages on disk, exposes a queue trigger type, and handles fan-out. Other workers register triggers like <code>queue::pop("dead-letters")</code> and the runtime calls them when messages arrive. To enqueue, you call <code>iii.trigger(&quot;queue::push&quot;, &#123; queue: &quot;dead-letters&quot;, body &#125;)</code>. No new vocabulary.
+            That is it. The worker stores messages on disk, exposes a queue trigger type, and handles fan-out. Other workers register triggers like <code>queue::pop("dead-letters")</code> and the runtime calls them when messages arrive. To enqueue, you call <code>{`iii.trigger("queue::push", { queue: "dead-letters", body })`}</code>. No new vocabulary.
           </p>
           <p>
             The same shape works for cron, pub/sub, state, and streams. Each one is a worker. Each one registers a small set of functions. Each one exposes a trigger type. The runtime stitches them together over the same transport that any other worker uses.

--- a/frontend/src/app/blog/three-primitives-replace-fifty-sdks/page.tsx
+++ b/frontend/src/app/blog/three-primitives-replace-fifty-sdks/page.tsx
@@ -78,39 +78,48 @@ pino            // logs
           <p>
             Here is a complete worker that exposes an HTTP endpoint, runs a cron job, and reacts to a queue message. One file, no extra services:
           </p>
-          <pre><code>{`use iii_sdk::{Client, RegisterFunction, RegisterTrigger, IIIError};
+          <pre><code>{`use iii_sdk::{register_worker, InitOptions, RegisterFunction, RegisterTrigger};
 use serde_json::json;
 
 #[tokio::main]
-async fn main() -> Result<(), IIIError> {
-    let client = Client::connect("ws://localhost:49134").await?;
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = std::env::var("III_URL")
+        .unwrap_or_else(|_| "ws://127.0.0.1:49134".to_string());
+    let iii = register_worker(&url, InitOptions::default());
 
-    client.register_worker("orders").await?;
-
-    client.register_function(
-        RegisterFunction::new_async("orders::handle", |ctx, input| async move {
+    iii.register_function(RegisterFunction::new_async(
+        "orders::handle",
+        |ctx, input| async move {
             let order_id = input["order_id"].as_str().unwrap();
             ctx.state().update("orders", order_id, json!({
                 "status": "received",
                 "received_at": ctx.now(),
             })).await?;
             Ok(json!({ "ok": true }))
-        }),
-    ).await?;
+        },
+    ));
 
-    client.register_trigger(RegisterTrigger::http()
-        .method("POST")
-        .api_path("orders/new")
-        .function("orders::handle")).await?;
+    iii.register_trigger(
+        RegisterTrigger::http()
+            .method("POST")
+            .api_path("orders/new")
+            .function("orders::handle"),
+    );
 
-    client.register_trigger(RegisterTrigger::cron()
-        .schedule("*/5 * * * *")
-        .function("orders::reconcile")).await?;
+    iii.register_trigger(
+        RegisterTrigger::cron()
+            .schedule("*/5 * * * *")
+            .function("orders::reconcile"),
+    );
 
-    client.register_trigger(RegisterTrigger::queue("dead-letters")
-        .function("orders::dlq")).await?;
+    iii.register_trigger(
+        RegisterTrigger::queue("dead-letters")
+            .function("orders::dlq"),
+    );
 
-    client.run().await
+    tokio::signal::ctrl_c().await?;
+    iii.shutdown_async().await;
+    Ok(())
 }`}</code></pre>
           <p>
             Read the file. Three triggers. One function shown, two more by name. Zero lines about retries, persistence, transport, or observability. The runtime takes those.
@@ -223,17 +232,19 @@ queue::pop     // pop a message and route it to a target function`}</code></pre>
           <p>
             Then start the engine, scaffold a worker, and call your first function:
           </p>
-          <pre><code>{`iii engine start
+          <pre><code>{`# start the engine — workers in config.yaml come up automatically
+iii
 
-# in another terminal
-iii worker new hello --rust
+# in another terminal — write the Rust crate yourself, then
 cd hello
 cargo run
 
-# in a third terminal
-iii fn call hello::greet --input '{"name":"Rohit"}'`}</code></pre>
+# in a third terminal — invoke any registered function over the same WebSocket
+iii trigger \\
+  --function-id='hello::greet' \\
+  --payload='{"name":"Rohit"}'`}</code></pre>
           <p>
-            The hello worker registers one function and one HTTP trigger. The CLI calls the function over the same transport an HTTP request would have used. There is no second &ldquo;serve&rdquo; mode.
+            The hello worker registers one function and one HTTP trigger. <code>iii trigger</code> calls that function over the same transport an HTTP request would have used. There is no second &ldquo;serve&rdquo; mode.
           </p>
 
           <h2>Closing</h2>

--- a/frontend/src/app/blog/three-primitives-replace-fifty-sdks/twitter-image.tsx
+++ b/frontend/src/app/blog/three-primitives-replace-fifty-sdks/twitter-image.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Three Primitives Are Enough: Rebuilding Backends Without Fifty SDKs'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', padding: '60px 80px', fontFamily: 'system-ui, -apple-system, sans-serif', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: '-100px', right: '-80px', width: '500px', height: '500px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(243,247,36,0.15) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ position: 'absolute', bottom: '-80px', left: '-80px', width: '400px', height: '400px', borderRadius: '50%', background: 'radial-gradient(circle, rgba(243,247,36,0.1) 0%, transparent 70%)', display: 'flex' }} />
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(243,247,36,0.15)', border: '1px solid rgba(243,247,36,0.3)' }}>
+            <span style={{ color: '#f3f724', fontSize: '16px', fontWeight: 600 }}>Backend</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(243,247,36,0.1)', border: '1px solid rgba(243,247,36,0.2)' }}>
+            <span style={{ color: '#f3f724', fontSize: '16px', fontWeight: 600 }}>Architecture</span>
+          </div>
+          <div style={{ display: 'flex', padding: '6px 16px', borderRadius: '20px', background: 'rgba(243,247,36,0.1)', border: '1px solid rgba(243,247,36,0.2)' }}>
+            <span style={{ color: '#f3f724', fontSize: '16px', fontWeight: 600 }}>Fundamentals</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+          <h1 style={{ color: '#f1f5f9', fontSize: '52px', fontWeight: 700, lineHeight: 1.15, margin: 0, letterSpacing: '-0.02em' }}>Three Primitives Are Enough</h1>
+          <p style={{ color: '#94a3b8', fontSize: '24px', fontWeight: 400, margin: '20px 0 0 0', lineHeight: 1.4 }}>Workers, functions, triggers — and the SDK explosion stops.</p>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '32px' }}>
+          <span style={{ color: '#475569', fontSize: '16px' }}>learndevrel.com</span>
+          <span style={{ color: '#475569', fontSize: '16px' }}>April 26, 2026 &middot; 14 min read</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}


### PR DESCRIPTION
## Summary
Three thought-leader blog posts dated across the last two weeks, written first-person in hands-on style.

| Date | Slug | Topic | Read time |
|------|------|-------|-----------|
| Apr 26, 2026 | three-primitives-replace-fifty-sdks | Workers/functions/triggers vs SDK explosion | 14 min |
| May 3, 2026 | agent-sandbox-runtimes-tested | E2B vs Daytona vs Modal vs Morph vs Vercel vs Docker sbx | 16 min |
| May 9, 2026 | content-addressed-memory-for-agents | Fingerprint IDs + reinforcement-on-write for agent memory | 15 min |

## Each post ships
- page.tsx (long-form prose, framer-motion intro, prose-invert styling)
- layout.tsx (per-post metadata + canonical + OG)
- opengraph-image.tsx + twitter-image.tsx (1200x630 edge runtime)

## Wiring
- All three prepended to blog-data.ts so they appear top-of-list
- Sitemap auto-includes via blog-data.ts loop

## Build
```
○ /blog/agent-sandbox-runtimes-tested
○ /blog/content-addressed-memory-for-agents
○ /blog/three-primitives-replace-fifty-sdks
```

## Test plan
- [ ] Vercel preview deploys
- [ ] /blog index lists all three at the top
- [ ] Each post page renders, code blocks readable, table renders on sandbox post
- [ ] /sitemap.xml contains all three slugs
- [ ] /blog/<slug>/opengraph-image and /twitter-image return 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new blog posts: "Agent Sandbox Runtimes Tested," "Content Addressed Memory for Agents," and "Three Primitives Replace Fifty SDKs," featuring in-depth technical articles with rich formatting and code examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/devrelguide/pull/20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->